### PR TITLE
Add video carousel slide and stinger page

### DIFF
--- a/content/stinger.md
+++ b/content/stinger.md
@@ -1,0 +1,10 @@
+---
+title: "Channel Intro"
+layout: post
+---
+
+# GUI Free Life — Channel Intro
+
+{{< video src="/videos/intro-5s.mp4" >}}
+
+{{< video src="/videos/outro-1s.mp4" >}}

--- a/data/carousel/stinger.yaml
+++ b/data/carousel/stinger.yaml
@@ -1,0 +1,9 @@
+weight: 0
+title: "GUI Free Life"
+description: >
+  <ul class="list-style-none">
+    <li>Open Source • Linux • Kubernetes</li>
+    <li>OpenShift • Networking • Automation</li>
+    <li>guifreelife.com</li>
+  </ul>
+video: "videos/intro-5s.mp4"

--- a/layouts/partials/carousel.html
+++ b/layouts/partials/carousel.html
@@ -1,0 +1,37 @@
+{{ if default true .Site.Params.CarouselHomepage.enable }}
+{{ if gt (len .Site.Data.carousel) 0 }}
+<section>
+    <div class="home-carousel">
+        <div class="dark-mask"></div>
+        <div class="container">
+            <div class="homepage owl-carousel"
+                data-autoplay="{{ default true .Site.Params.CarouselHomepage.auto_play }}"
+                data-slide-speed="{{ default 2000 .Site.Params.CarouselHomepage.slide_speed }}"
+                data-pagination-speed="{{ default 1000 .Site.Params.CarouselHomepage.pagination_speed }}">
+                {{ range sort .Site.Data.carousel "weight" }}
+                <div class="item">
+                    <div class="row">
+                        <div class="col-sm-5 right">
+                            <h1>{{ .title }}</h1>
+                            {{ .description | safeHTML }}
+                        </div>
+                        <div class="col-sm-7">
+                            {{ if .video }}
+                            <video autoplay muted loop playsinline
+                                   style="width:100%; border-radius:4px;">
+                                <source src="{{ .video }}" type="video/mp4">
+                            </video>
+                            {{ else }}
+                            <img class="img-responsive" src="{{ .image }}" alt="">
+                            {{ end }}
+                        </div>
+                    </div>
+                </div>
+                {{ end }}
+            </div>
+            <!-- /.project owl-slider -->
+        </div>
+    </div>
+</section>
+{{ end }}
+{{ end }}

--- a/layouts/shortcodes/video.html
+++ b/layouts/shortcodes/video.html
@@ -1,0 +1,14 @@
+{{/* {{< video src="/videos/intro-5s.mp4" >}}
+   Optional params: poster="/img/thumb.jpg" controls="false" */}}
+{{ $src      := .Get "src" }}
+{{ $poster   := .Get "poster"   | default "" }}
+{{ $controls := .Get "controls" | default "true" }}
+<div class="video-container" style="text-align:center; margin:2em 0;">
+  <video {{ if ne $controls "false" }}controls{{ end }}
+         style="max-width:100%; border-radius:4px; box-shadow:0 4px 16px rgba(0,0,0,.4);"
+         {{ if $poster }}poster="{{ $poster }}"{{ end }}
+         preload="metadata">
+    <source src="{{ $src }}" type="video/mp4">
+    Your browser does not support the video tag.
+  </video>
+</div>


### PR DESCRIPTION
## Summary

- Overrides the theme carousel partial to support a `video:` field alongside the existing `image:` field — if `video:` is set, renders an autoplaying muted looping `<video>` element instead of `<img>`; existing slides are unaffected
- Adds a `stinger` carousel slide (weight 0, first position) playing `videos/intro-5s.mp4`
- Adds a reusable `{{< video src="..." >}}` shortcode with optional `poster` and `controls` params
- Adds `content/stinger.md` — a static page embedding both the intro and outro stinger videos

## Test plan

- [x] Homepage carousel: stinger video plays as first slide, autoplay/muted/loop, subsequent image slides unaffected
- [x] `http://localhost:1313/stinger/` renders both videos with controls
- [x] `{{< video src="/videos/intro-5s.mp4" controls="false" >}}` hides controls
- [x] Theme carousel partial untouched (override lives in `layouts/partials/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)