### PR TITLE
Update blog posts: CoreOS Image Layering and VLAN Guest Tagging

### DIFF
--- a/content/blog/CoreOS-Image-Layering-Autofs.md
+++ b/content/blog/CoreOS-Image-Layering-Autofs.md
@@ -10,10 +10,10 @@ tags:
   - openshift
   - kubernetes
   - operators
-description: CoreOS On-cluster Image Layering in OpenShift 4.19 allows modifications to node the operating system. This detailed walk through customizes the node operating system image by adding RPMs to support autofs.
+description: CoreOS On-cluster Image Layering in OpenShift allows modifications to node the operating system. This detailed walk through customizes the node operating system image by adding RPMs to support autofs.
 ---
 
-CoreOS On-cluster Image Layering in OpenShift 4.19 allows modifications to node the operating system. This detailed walk through customizes the node operating system image by adding RPMs to support autofs.
+CoreOS On-cluster Image Layering added in OpenShift 4.19 allows modifications to the node operating system. This detailed walk through customizes the node operating system image by adding RPMs to support autofs.
 
 In [part 2][14] we will configure autofs and enable automatic filesystem mounting across cluster nodes.
 
@@ -77,7 +77,7 @@ The custom image we are creating must be pushed to a container image registry. T
 
 ## Creating Pull Secrets for the Image Build
 
-To upload (push) or download (pull) an image from a registry requires a credential called a "pull-secret". 
+To upload (push) or download (pull) an image from a registry requires a credential called a "pull-secret".
 
 OpenShift includes a global pull secret which is supplied during installation and stored in the `openshift-config` namespace. This has privilege to download the base CoreOS image, but we also need a credential to push our custom image to a registry.
 
@@ -192,7 +192,7 @@ metadata:
 spec:
   machineConfigPool:
     name: worker-automount
-  containerFile: 
+  containerFile:
   - content: |-
       FROM configs AS final
       RUN dnf install -y \
@@ -201,15 +201,15 @@ spec:
         openldap-clients \
         && dnf clean all \
         && ostree container commit
-  imageBuilder: 
+  imageBuilder:
     imageBuilderType: Job
-  baseImagePullSecret: 
+  baseImagePullSecret:
     # baseImagePullSecret is the secret used to pull the base image
     name: pull-and-push-secret
-  renderedImagePushSecret: 
+  renderedImagePushSecret:
     # renderedImagePushSecret is the secret used to push the custom image
     name: push-secret
-  renderedImagePushSpec: image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/os-image:latest 
+  renderedImagePushSpec: image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/os-image:latest
 ```
 _[MachineOSConfig][4]_
 
@@ -225,7 +225,7 @@ On line 7 we are specifying that this MachineOSConfig is to be applied to the "w
 Here is what happens when you create a `MachineOSConfig` named "worker-automount":
 * creates a `deployment/machine-os-builder` which creates a `pod/machine-os-builder-<hash>`
 * `pod/machine-os-builder-<hash>` waits to acquire a lease
-* `pod/machine-os-builder-<hash>` creates a `machineosbuild/worker-automount-<hash>` resource  
+* `pod/machine-os-builder-<hash>` creates a `machineosbuild/worker-automount-<hash>` resource
 * `pod/machine-os-builder-<hash>` creates a `job/build-worker-automount-<hash>`
 * `job/build-worker-automount-<hash>`  creates a `pod/build-worker-automount-<hash>` to perform the build.
 * This pod log shows the build progress. ^

--- a/content/blog/OpenShift-Virtualization-VLAN-Guest-Tagging.md
+++ b/content/blog/OpenShift-Virtualization-VLAN-Guest-Tagging.md
@@ -3,17 +3,17 @@ title: "OpenShift Virtual Guest Tagging"
 date: 2025-01-02
 banner: /images/vgt-trunk.jpeg
 layout: post
-mermaid: false
+mermaid: true
 asciinema: true
 tags:
   - networking
   - openshift
   - kubernetes
   - virtualization
-description: Some workloads require the use of VLAN tagged interfaces in virtual machines. VMware terms this feature VGT. OpenShift Virtualization supports this feature using traditional Linux Bridge interfaces. This post details and demonstrates an implementation.
+description: Some workloads require the use of VLAN tagged interfaces in virtual machines. VMware calls this feature VGT. OpenShift Virtualization supports this feature using traditional Linux Bridge interfaces. This post details and demonstrates an implementation.
 ---
 
-Some workloads require the use of VLAN interfaces in virtual machines. VMware terms this feature "Virtual Guest Tagging" or "VLAN Guest Tagging" while OpenStack calls it "VLAN-aware instances". See how OpenShift Virtualization can pass 802.1q trunks to VMs using a traditional Linux Bridge interface.
+Some workloads require the use of VLAN interfaces in virtual machines. VMware calls this feature "Virtual Guest Tagging" or "VLAN Guest Tagging" while OpenStack calls it "VLAN-aware instances". See how OpenShift Virtualization can pass 802.1q trunks to VMs using a traditional Linux Bridge interface.
 
 <!--more-->
 
@@ -37,9 +37,79 @@ OpenShift uses the [OVN-Kubernetes][4] CNI which includes support for a `localne
 
 Fortunately this can be accomplished using a Linux Bridge interface. Despite the name, a Linux Bridge has intelligence for handling frame construction and the ports attached to it like a switch.
 
-{{< figure src="/images/openshift-virt-vgt-node.png" title="OpenShift Node with 3 bridges" alt="OpenShift Node networking" >}}
+<!-- {{< figure src="/images/openshift-virt-vgt-node.png" title="OpenShift Node with 3 bridges" alt="OpenShift Node networking" >}} -->
+
+
+```mermaid
+graph BT;
+    subgraph Cluster[" "]
+
+
+        subgraph ns-client["📦 <b>firewall</b> Namespace"]
+          nad-vgt-client[NAD<br> 🛜 trunk]
+          subgraph vm-client["🔥 Firewall"]
+              vgt-client-eth0[eth0 🔌]
+              vgt-client-vlan1[eth0.1 🏷️]:::Vlan1
+              vgt-client-vlan2[eth0.2 🏷️]:::Vlan2
+          end
+        end
+
+      subgraph node1["🖥️ Node "]
+        br-ex[ OVS Bridge<br> 🔗 br-ex]
+        br-vmdata[ OVS Bridge<br> 🔗 br-vmdata]
+        br-linux[ Linux Bridge<br> 🔗 br-trunk]
+        node1-bond0[ens192 🔌]
+        node1-bond1[ens224 🔌]
+        node1-bond2[ens256 🔌]
+      end
+    end
+
+    br-ex --> node1-bond0
+    br-vmdata --> node1-bond1
+    br-linux --> node1-bond2
+    vgt-client-eth0 <==(🏷️ 802.1q trunk)==> br-linux
+    vgt-client-eth0 -.-> nad-vgt-client
+    nad-vgt-client -.->  br-linux
+    vgt-client-vlan1 --> vgt-client-eth0
+    vgt-client-vlan2 --> vgt-client-eth0
+
+    Internet["☁️ "]:::Internet
+    node1-bond0 ==default gw==> Internet
+    node1-bond1 ==(🏷️ 802.1q trunk)==> Internet
+    node1-bond2 ==(🏷️ 802.1q trunk)==> Internet
+
+    classDef bond0 fill:#37A3A3,color:#fff,stroke:#333,stroke-width:2px
+    class br-ex,physnet-ex,node1-bond0 bond0
+
+    classDef bond1 fill:#9ad8d8,color:#fff,stroke:#333,stroke-width:2px
+    class br-vmdata,physnet-vmdata,node1-bond1 bond1
+
+    classDef bond2 fill:#daf2f2,color:#004d4d,stroke:#333,stroke-width:2px
+    class nad-vgt-client,vgt-client-eth0,br-linux,node1-bond2 bond2
+
+    classDef Vlan1 fill:#fae2f2,color:#004d4d,stroke:#333,stroke-width:2px
+    classDef Vlan2 fill:#daffd2,color:#004d4d,stroke:#333,stroke-width:2px
+
+    classDef labels stroke-width:1px,color:#fff,fill:#005577
+    classDef networks fill:#cdd,stroke-width:0px
+
+    style Cluster color:#000,fill:#fff,stroke:#333,stroke-width:0px
+    style Internet fill:none,stroke-width:0px,font-size:+2em
+
+    classDef nodes fill:#fff,stroke:#000,stroke-width:3px
+    class node1,node2,node3 nodes
+
+    classDef vm color:#000,fill:#eee,stroke:#000,stroke-width:2px
+    class vm-client,vm-ldap,vm-nfs vm
+
+    classDef namespace color:#000,fill:#fff,stroke:#000,stroke-width:2px;
+    class ns-nfs,ns-client,ns-ldap namespace;
+```
 
 Above is a diagram of a node having 3 bridges. Bridge `br-ex` is the default management interface, the second `br-vmdata` was created to attach VMs to provider networks as `localnet` secondary networks. Both of these bridges are  OVS Bridges. The third bridge `br-trunk` is a [Linux Bridge][8] and was created only for the use case we are discussing here.
+
+The Firewall virtual machine has a single `eth0` physical interface, but it is receiving the 802.1q tags from the physical network which enables it to create VLAN logical interfaces for each tag.
+
 
 ## Creating the Linux Bridge
 


### PR DESCRIPTION
## Summary

- Refine CoreOS Image Layering documentation for clarity, improved phrasing, and consistent YAML formatting
- Update OpenShift Virtualization VLAN Guest Tagging post with a Mermaid network diagram and clearer Linux Bridge explanation

## Test plan

- [ ] Verify Hugo renders both blog posts without errors
- [ ] Confirm Mermaid diagram renders correctly in the VLAN Guest Tagging post
- [ ] Check that YAML code blocks in CoreOS Image Layering post are properly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)