### PR TITLE
Add robots.txt with AI bot directives

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,53 @@
+# Content Signals: purpose-based crawl permissions
+# https://www.cloudflare.com/learning/bots/what-is-content-signals/
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
+
+# Default: allow all well-behaved crawlers, including AI assistants and training crawlers
+User-agent: *
+Allow: /
+
+# AI assistants fetching pages on behalf of a user
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: Claude-User
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+# AI training crawlers
+User-agent: GPTBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: Meta-ExternalAgent
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+Sitemap: http://guifreelife.com/sitemap.xml


### PR DESCRIPTION
## Summary
- Adds `static/robots.txt` with explicit AI crawler directives (Hugo copies it to the site root).
- Declares a Content-Signal header (`search=yes, ai-input=yes, ai-train=yes`) for purpose-based crawl permissions.
- Allows user-facing AI assistants (ChatGPT-User, Claude-User, PerplexityBot, OAI-SearchBot, etc.) and training crawlers (GPTBot, ClaudeBot, Google-Extended, CCBot, etc.).
- References the sitemap.

## Why
Resolves the Discovery gap flagged by [orank](https://ora.run/score/guifreelife.com)'s agent-readiness scan: "No robots.txt found." Site owner is fine with AI training, so all categories are allowed.

## Test plan
- [ ] Verify `robots.txt` is published at `https://guifreelife.com/robots.txt` after deploy
- [ ] Re-run the orank scan and confirm the Discovery score increases

🤖 Generated with [Claude Code](https://claude.com/claude-code)