### PR TITLE
Fix Hugo deprecations and build-breaking gist shortcode removal

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,7 +2,7 @@
 baseurl = "http://guifreelife.com"
 title = "GUI Free Life"
 themesDir = "themes"
-languageCode = "en-us"
+locale = "en-us"
 # Site language. Available translations in the theme's `/i18n` directory.
 defaultContentLanguage = "en"
 enableEmoji = true
@@ -140,7 +140,7 @@ pagerSize = 10
       """
 
 [Permalinks]
-    blog = "/blog/:year/:month/:day/:filename/"
+    blog = "/blog/:year/:month/:day/:contentbasename/"
 
 [params.mermaid]
     theme = "base"

--- a/layouts/partials/carousel.html
+++ b/layouts/partials/carousel.html
@@ -1,5 +1,5 @@
 {{ if default true .Site.Params.CarouselHomepage.enable }}
-{{ if gt (len .Site.Data.carousel) 0 }}
+{{ if gt (len hugo.Data.carousel) 0 }}
 <section>
     <div class="home-carousel">
         <div class="dark-mask"></div>
@@ -8,7 +8,7 @@
                 data-autoplay="{{ default true .Site.Params.CarouselHomepage.auto_play }}"
                 data-slide-speed="{{ default 2000 .Site.Params.CarouselHomepage.slide_speed }}"
                 data-pagination-speed="{{ default 1000 .Site.Params.CarouselHomepage.pagination_speed }}">
-                {{ range sort .Site.Data.carousel "weight" }}
+                {{ range sort hugo.Data.carousel "weight" }}
                 <div class="item">
                     <div class="row">
                         <div class="col-sm-5 right">

--- a/layouts/shortcodes/gist.html
+++ b/layouts/shortcodes/gist.html
@@ -1,0 +1,3 @@
+{{- /* Replaces Hugo's built-in gist shortcode, removed in v0.156.0.
+     Usage: {{< gist user id [filename] >}} */ -}}
+<script type="application/javascript" src="https://gist.github.com/{{ .Get 0 }}/{{ .Get 1 }}.js{{ with .Get 2 }}?file={{ . }}{{ end }}"></script>

--- a/themes/hugo-universal-theme/layouts/404.html
+++ b/themes/hugo-universal-theme/layouts/404.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
+<html lang="{{ .Site.Language.Locale }}">
 
   <head>
     {{ partial "headers.html" . }}

--- a/themes/hugo-universal-theme/layouts/_default/list.html
+++ b/themes/hugo-universal-theme/layouts/_default/list.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
+<html lang="{{ .Site.Language.Locale }}">
 
   <head>
     {{ partial "headers.html" . }}

--- a/themes/hugo-universal-theme/layouts/_default/single.html
+++ b/themes/hugo-universal-theme/layouts/_default/single.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
+<html lang="{{ .Site.Language.Locale }}">
 
   <head>
     {{ partial "headers.html" . }}

--- a/themes/hugo-universal-theme/layouts/index.html
+++ b/themes/hugo-universal-theme/layouts/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
+<html lang="{{ .Site.Language.Locale }}">
 
   <head>
     {{ partial "headers.html" . }}

--- a/themes/hugo-universal-theme/layouts/page/single.html
+++ b/themes/hugo-universal-theme/layouts/page/single.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
+<html lang="{{ .Site.Language.Locale }}">
 
   <head>
     {{ partial "headers.html" . }}

--- a/themes/hugo-universal-theme/layouts/partials/carousel.html
+++ b/themes/hugo-universal-theme/layouts/partials/carousel.html
@@ -1,5 +1,5 @@
 {{ if default true .Site.Params.CarouselHomepage.enable }}
-{{ if gt (len .Site.Data.carousel) 0 }}
+{{ if gt (len hugo.Data.carousel) 0 }}
 <section>
     <div class="home-carousel">
         <div class="dark-mask"></div>
@@ -8,7 +8,7 @@
                 data-autoplay="{{ default true .Site.Params.CarouselHomepage.auto_play }}"
                 data-slide-speed="{{ default 2000 .Site.Params.CarouselHomepage.slide_speed }}"
                 data-pagination-speed="{{ default 1000 .Site.Params.CarouselHomepage.pagination_speed }}">
-                {{ range sort .Site.Data.carousel "weight" }}
+                {{ range sort hugo.Data.carousel "weight" }}
                 <div class="item">
                     <div class="row">
                         <div class="col-sm-5 right">

--- a/themes/hugo-universal-theme/layouts/partials/clients.html
+++ b/themes/hugo-universal-theme/layouts/partials/clients.html
@@ -1,6 +1,6 @@
 {{ if isset .Site.Params "clients" }}
 {{ if .Site.Params.clients.enable }}
-{{ if gt (len .Site.Data.clients) 0 }}
+{{ if gt (len hugo.Data.clients) 0 }}
 <section class="bar background-gray no-mb">
     <div class="container">
         <div class="row">
@@ -18,7 +18,7 @@
                     data-autoplay="{{ default false .Site.Params.CarouselCustomers.auto_play }}"
                     data-slide-speed="{{ default 2000 .Site.Params.CarouselCustomers.slide_speed }}"
                     data-pagination-speed="{{ default 1000 .Site.Params.CarouselCustomers.pagination_speed }}">
-                    {{ range .Site.Data.clients }}
+                    {{ range hugo.Data.clients }}
                     <li class="item" title="{{ .name }}">
                         {{ if .url }}
                           <a href="{{ .url }}" target="_blank">

--- a/themes/hugo-universal-theme/layouts/partials/features.html
+++ b/themes/hugo-universal-theme/layouts/partials/features.html
@@ -1,10 +1,10 @@
 {{ if isset .Site.Params "features" }}
 {{ if .Site.Params.features.enable }}
-{{ if gt (len .Site.Data.features) 0 }}
+{{ if gt (len hugo.Data.features) 0 }}
 <section class="bar background-white">
     <div class="container">
         {{ $elements := default 3 .Site.Params.features.cols }}
-        {{ $features := sort .Site.Data.features "weight" }}
+        {{ $features := sort hugo.Data.features "weight" }}
 
         {{ $total_rows := div (len $features) $elements }}
 

--- a/themes/hugo-universal-theme/layouts/partials/headers.html
+++ b/themes/hugo-universal-theme/layouts/partials/headers.html
@@ -75,7 +75,7 @@
 {{ $is_valid_image := print "static/" $image | fileExists }}
 {{ if $is_valid_image }}
 {{ $image_ext := path.Ext $image }}
-<meta property="og:locale" content="{{ replace .Site.LanguageCode "-" "_" }}">
+<meta property="og:locale" content="{{ replace .Site.Language.Locale "-" "_" }}">
 <meta property="og:site_name" content="{{ .Site.Title }}">
 <meta property="og:title" content="{{ $title_plain }}">
 <meta property="og:type" content="{{ cond $is_blog "article" "website" }}">

--- a/themes/hugo-universal-theme/layouts/partials/testimonials.html
+++ b/themes/hugo-universal-theme/layouts/partials/testimonials.html
@@ -1,6 +1,6 @@
 {{ if isset .Site.Params "testimonials" }}
 {{ if .Site.Params.testimonials.enable }}
-{{ if gt (len .Site.Data.testimonials) 0 }}
+{{ if gt (len hugo.Data.testimonials) 0 }}
 <section class="bar background-pentagon no-mb">
     <div class="container">
         <div class="row">
@@ -20,7 +20,7 @@
                     data-autoplay="{{ default false .Site.Params.CarouselTestimonals.auto_play }}"
                     data-slide-speed="{{ default 2000 .Site.Params.CarouselTestimonals.slide_speed }}"
                     data-pagination-speed="{{ default 1000 .Site.Params.CarouselTestimonals.pagination_speed }}">
-                    {{ range .Site.Data.testimonials }}
+                    {{ range hugo.Data.testimonials }}
                     <li class="item">
                         <div class="testimonial same-height-always">
                             <div class="text">


### PR DESCRIPTION
## What

Clears all Hugo deprecation warnings and a build-breaking removal that surfaced on newer Hugo (validated on v0.164.0). Started from the two deprecations in `make preview`; fixing them let the build run far enough to reveal the rest.

### Config (`config.toml`)
- `languageCode` → `locale` (deprecated in v0.158.0)
- Permalink token `:filename` → `:contentbasename` (removed in v0.144.0). Resolves to the same content basename — **blog URLs are unchanged**.

### New shortcode (`layouts/shortcodes/gist.html`)
- Hugo **removed** the built-in `gist` shortcode in v0.156.0, which broke the build (7 embeds across 6 posts). This drop-in reproduces the old `gist.github.com/<user>/<id>.js` embed plus the optional filename argument — **no content edits needed**.

### Template calls (own override + vendored theme)
- `.Site.Data` → `hugo.Data` (deprecated in v0.156.0)
- `.Site.LanguageCode` → `.Site.Language.Locale` (deprecated in v0.158.0)

## Why

`hugo server -D` was emitting deprecation warnings and, on current Hugo, failing to build because of the removed `gist` shortcode.

## Verification

Ran `hugo server -D` on Hugo v0.164.0:
- Clean build — zero deprecation warnings/errors
- Gist embeds render correctly (including the `?file=` filename filter)
- Blog permalinks and original-case slugs unchanged

## Reviewer notes

- The theme edits diverge `themes/hugo-universal-theme/` from upstream. The theme is tracked directly in this repo (not a submodule), so a future theme update could clobber these or reintroduce the deprecations — worth re-applying/upstreaming if you pull theme updates.
- Two pre-existing "Raw HTML omitted" (goldmark `unsafe`) warnings remain — unrelated to this change and left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)