### PR TITLE
ci: bump pinned Hugo to 0.164.0 to fix broken deploy build

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.147.8'
+          hugo-version: '0.164.0'
           extended: true
 
       - name: Setup Ruby


### PR DESCRIPTION
## What

Bumps the `gh-pages` deploy workflow's pinned Hugo from **0.147.8 → 0.164.0**.

## Why

The workflow was pinned to Hugo 0.147.8 (~3 years old), while local development uses 0.164.0. After #27 modernized the templates and config for current Hugo, the deploy build [failed on every page](https://github.com/dlbewley/guifreelife-src/actions/runs/29294969626):

```
executing "404.html" at <.Site.Language.Locale>:
can't evaluate field Locale in type *langs.Language
```

`.Site.Language.Locale`, the `locale` config key, and `hugo.Data` all require a newer Hugo than 0.147.8. This is a version mismatch, not a bug in #27 — the fix is to align CI with the version the fixes were written and verified against.

## Verification

Ran the workflow's exact build command on v0.164.0:

```
$ hugo --minify
EXIT CODE: 0
```

Clean build, no errors or deprecation warnings (only the pre-existing goldmark raw-HTML notices remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)